### PR TITLE
Added VOLUME to Dockerfile for persistent mapping of nodervisor.sqlit…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #    `docker build -t nodervisor .`
 # to run, using sqlite database bind-mounted from host system:
 #    `touch nodervisor.sqlite`
-#    `docker run -p 3000:3000 -v nodervisor.sqlite:/opt/nodervisor/nodervisor.sqlite nodervisor`
+#    `docker run -p 3000:3000 -v $(pwd)/nodervisor.sqlite:/opt/nodervisor/nodervisor.sqlite nodervisor`
 
 FROM ubuntu:14.04
 MAINTAINER "Joshua C. Randall" <jcrandall@alum.mit.edu>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-# 
+#
 # nodervisor Dockerfile
 #
 # to build:
 #    `docker build -t nodervisor .`
-# to run, using sqlite database bind-mounted from host system: 
+# to run, using sqlite database bind-mounted from host system:
 #    `touch nodervisor.sqlite`
 #    `docker run -p 3000:3000 -v nodervisor.sqlite:/opt/nodervisor/nodervisor.sqlite nodervisor`
 
@@ -24,6 +24,9 @@ WORKDIR /opt/nodervisor
 
 # Install npm packages for nodervisor
 RUN npm install
+
+# Volume
+VOLUME /opt/nodervisor
 
 # Run npm start by default
 CMD ["/usr/bin/npm","start"]


### PR DESCRIPTION
I could not bind-mount the nodervisor.sqlite file from my host system to the container. Defining a mount point in the Dockerfile fixed that problem (see commit).

Now, I'm able to persist the changes and recover in case of container failure.
